### PR TITLE
Initiera spelbräde för Wordle-klon

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,43 @@
+body {
+    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    background-color: #f0f0f0;
+}
+
+h1 {
+    margin-bottom: 20px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 5px;
+    max-width: 300px;
+}
+
+.box {
+    width: 50px;
+    height: 50px;
+    border: 2px solid #333;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    font-weight: bold;
+    background-color: white;
+    border-radius: 4px;
+}
+
+.box.empty {
+    background-color: var(--empty);
+}
+.box.wrong {
+    background: var(--wrong);
+}
+
+.box.right {
+    background: var(--right)
+}

--- a/static/js/game.js
+++ b/static/js/game.js
@@ -1,14 +1,46 @@
-const ROWS = 6;
-const COLS = 5;
-let currentRow = 0;
-let currentCol = 0;
-let secretWord = "hej";
+const state = {
+    grid: Array(6)
+          .fill()
+          .map(() => Array(5).fill('')),
+          currentRow: 0,
+          currentColumn: 0,
+};
 
 
-function initGame() 
+function createBox(container, row, column, letter = '')
+    {
+        const box = document.createElement('div');
+        box.className = 'box';
+        box.id = `box${row}${column}`;
+        box.textContent = letter;
+
+        container.appendChild(box);
+        return box;
+    }
+function drawGrid(container)
 {
-    console.log("Game has started")
-    console.log("secretWord: " , secretWord);
+    const grid = document.createElement('div');
+    grid.className = 'grid';
+
+    for(let i = 0; i < 6;i++)//antal rader
+    {
+        for(let j = 0; j < 5; j++) //antal kolumner 
+        {
+            createBox(grid,i,j);
+        }
+    }
+    container.appendChild(grid);
+}
+
+
+function initGame() //startar spelet
+{
+    const game = document.getElementById('game');
+    if (game) {
+        drawGrid(game);
+    } else {
+        console.error('Element with id="game" not found!');
+    }
 }
 
 document.addEventListener("DOMContentLoaded", initGame);

--- a/temples/index.html
+++ b/temples/index.html
@@ -3,9 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Wordle Clone - Test</title>
+    <link rel="stylesheet" href="../static/css/style.css">
 </head>
 <body>
+    <h1>Wordle Grid </h1>
+    <div id="game"></div>
     <script src="../static/js/game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Lägger till spelstate och genererar ett 6x5 spelbräde dynamiskt i DOM:en.
Initierar spelet automatiskt vid sidladdning och hanterar avsaknad av #game-element.